### PR TITLE
[bug] Correctly handle window path in on_modified

### DIFF
--- a/src/whitelist_api/whitelist_api/api.py
+++ b/src/whitelist_api/whitelist_api/api.py
@@ -35,7 +35,8 @@ class FileEventHandler(FileSystemEventHandler):
 
     def on_modified(self, event: Union[DirModifiedEvent, FileModifiedEvent]) -> None:
         # compare relative path with absolute path
-        if event.src_path.endswith(self.__api.whitelist_file_path()):
+        report_path = Path(event.src_path).as_posix()
+        if report_path.endswith(self.__api.whitelist_file_path()):
             self.__api.load_whitelist()
 
 


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

修复 #75 中说述内容

bug 原理：
`event.src_path` 在 window 系统下会返回Window样式路径 `server\whitelist.json` 

修复方法：
通过 `pathlib` 中 `Path().as_posix()` 方法将 `event.src_path` 转换成标准路径 (使用`/`)