### PR TITLE
fix(whitelist_api): 基岩版玩家白名单添加与查重逻辑

### DIFF
--- a/src/whitelist_api/whitelist_api/__init__.py
+++ b/src/whitelist_api/whitelist_api/__init__.py
@@ -57,9 +57,11 @@ def add_online_player(player: str):
 
 def add_floodgate_player(player: str, prefix:str='.'):
     players = get_whitelist_names()
-    if player in players:
+    if player.startswith(prefix):
+        player = player[1:]
+    if prefix + player in players:
         raise WhitelistException(f"{player} is already exist")
-    __psi.execute(f'fwhitelist add {prefix}{player}')
+    __psi.execute(f'fwhitelist add {player}')
 
 
 def remove_player(player: str, force_offline: bool = False):


### PR DESCRIPTION
- 在添加基岩版玩家白名单进行查重时自动包含前缀，解决无法添加与java版重名的基岩ID的问题。
- 调用`fwhitelist add`时不包含前缀，前缀应由floodgate管理。

**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。