### PR TITLE
feat(whitelist_api): detect Velocity online-mode when server.properties has online-mode=false

### DIFF
--- a/src/whitelist_api/requirements.txt
+++ b/src/whitelist_api/requirements.txt
@@ -1,2 +1,3 @@
 watchdog>=5.0.2
 pathlib>=1.0.1
+PyYAML>=5.4

--- a/src/whitelist_api/whitelist_api/api.py
+++ b/src/whitelist_api/whitelist_api/api.py
@@ -1,11 +1,13 @@
 import json
 import logging
+import yaml
 from pathlib import Path
 from json import JSONDecodeError
 from typing import List, Optional, Union
 
 watch_enable: False
 _default_server_properties = 'server.properties'
+_default_paper_config = "config/paper-global.yml"
 _default_whitelist_json = 'whitelist.json'
 
 try:
@@ -119,13 +121,25 @@ class WhitelistApi:
         self.__logger.info('whitelist api watchdog stopped')
 
     def refresh_online_mode(self) -> Optional[bool]:
+        found = False
         with open(self.server_directory / _default_server_properties, mode='r', encoding='UTF-8') as props:
             line = props.readline()
             while line:
                 # trim '\n'
                 kv = line[:-1].split('=')
                 if len(kv) == 2 and kv[0] == 'online-mode':
+                    found = True
                     self.__online_mode = True if kv[1] == 'true' else False
-                    return self.__online_mode
+                    break
                 line = props.readline()
-        return None
+        if not found:
+            return None
+        if not self.__online_mode:  # Check if paper-global.yml is present. If yes, check if velocity and velocity's online-mode is enabled.
+            try:
+                with open(self.server_directory / _default_paper_config , mode='r', encoding='UTF-8') as config:
+                    props = yaml.safe_load(config)
+                    velocity = props.get('proxies', {}).get('velocity', {})
+                    self.__online_mode = velocity.get('enabled', False) and velocity.get('online-mode', False)
+            except (FileNotFoundError, yaml.YAMLError):
+                self.__online_mode = False
+        return self.__online_mode


### PR DESCRIPTION
**在提出此拉取请求时，我确认了以下几点（请复选框）：**

- [x] 我已检查没有与此请求重复的拉取请求。
- [x] 我已经考虑过，并确认这份呈件对其他人很有价值。
- [x] 我接受此提交可能不会被使用，并根据维护人员的意愿关闭拉取请求。

**填写PR内容：**

- 在server.properties中的online-mode为false时额外检查paper-global.yml中的velocity字段，若开启velocity则以velocity中的online-mode为准。此改动是因为paper服务器在使用velocity连接时在server.properties中要将online-mode设置为false，即使服务器通过velocity进行在线玩家验证。
- 现需要pyyaml库。